### PR TITLE
#13 Fix SSE socket/log footguns and one-shot Content-Length path

### DIFF
--- a/src/datastar.zig
+++ b/src/datastar.zig
@@ -157,7 +157,12 @@ pub const SSEOptions = struct {
 };
 
 pub const SSE = struct {
-    stream: *std.http.BodyWriter,
+    /// Streaming body writer for sync/long-lived SSE. Null for one-shot
+    /// responses, which defer to `req.respond` with Content-Length on close().
+    stream: ?*std.http.BodyWriter = null,
+    /// Set for one-shot SSE so close() can emit a single Content-Length response.
+    req: ?*std.http.Server.Request = null,
+    headers: []const std.http.Header = &.{},
     output_buffer: Io.Writer.Allocating,
     msg: ?Message = null,
     buffer_size: usize = DEFAULT_BUFFER_SIZE,
@@ -173,29 +178,41 @@ pub const SSE = struct {
 
     pub fn flush(self: *SSE) !void {
         if (self.msg) |*msg| try msg.end();
+        const stream = self.stream orelse {
+            // One-shot: keep framed bytes in output_buffer for close() → respond().
+            return;
+        };
         const data = self.output_buffer.written();
 
         // write to the bodyWriter, on flush this gets chunked and forwarded to the final_output
-        try self.stream.writer.writeAll(data);
+        try stream.writer.writeAll(data);
 
         if (self.sync) {
             // in sync mode, we need to manually trip the end-of-chunk by adding \r\n
             // then tell the BodyWriter to flush itself to the underlying socket connection
-            try self.stream.writer.writeAll("\r\n");
-            try self.stream.writer.flush();
-            try self.stream.flush(); // flushing the BodyWriter does the work of writing to the http_protocol_output
+            try stream.writer.writeAll("\r\n");
+            try stream.writer.flush();
+            try stream.flush(); // flushing the BodyWriter does the work of writing to the http_protocol_output
             _ = self.output_buffer.writer.consume(data.len + 2);
             return;
         }
         _ = self.output_buffer.writer.consume(data.len);
     }
 
-    /// close() is used for short lived SSE only
-    /// on close(), this will populate the response body the call res.write()
-    /// which will output both the header and the body using async IO
+    /// close() finishes a short-lived SSE.
+    /// One-shot (non-sync): single `respond` with Content-Length — no chunked
+    /// framing, no second body buffer copy onto a BodyWriter.
+    /// Sync/streaming: flush remaining buffer and end the chunked stream.
     pub fn close(self: *SSE) void {
-        self.stream.writer.writeAll(self.body()) catch {};
-        self.stream.end() catch {};
+        if (self.stream) |stream| {
+            stream.writer.writeAll(self.body()) catch {};
+            stream.end() catch {};
+            return;
+        }
+        const req = self.req orelse return;
+        self.flush() catch {};
+        const data = self.output_buffer.written();
+        req.respond(data, .{ .extra_headers = self.headers }) catch {};
     }
 
     // Sends a keepalive packet on a connected SSE
@@ -348,6 +365,7 @@ pub fn readSignals(comptime T: type, arena: std.mem.Allocator, req: *std.http.Se
     }
 }
 
+
 pub const Message = struct {
     out_buffer: *Io.Writer = undefined, // an intermediate buffer to write the expanded Datastar event stream to
     input_buffer: [8 * 1024]u8 = undefined,
@@ -497,7 +515,6 @@ pub const Message = struct {
 
     fn drain(w: *Io.Writer, data: []const []const u8, splat: usize) Io.Writer.Error!usize {
         var self: *Message = @fieldParentPtr("interface", w);
-        _ = splat;
 
         if (!self.started) {
             try self.header();
@@ -508,9 +525,18 @@ pub const Message = struct {
         if (w.end > 0) {
             written += try writeBytesScan(self, self.out_buffer, w.buffered());
         }
-        written += try writeBytesScan(self, self.out_buffer, data[0]);
+        if (data.len == 0) return w.consume(written);
 
-        // TODO - we have the expanded contents in self.out_buffer here - debug that, then send the whole contents of the out_buffer to the self.stream_writer
+        // Honor the Writer vector contract: every slice, then splat of the last.
+        for (data[0 .. data.len - 1]) |chunk| {
+            written += try writeBytesScan(self, self.out_buffer, chunk);
+        }
+        const last = data[data.len - 1];
+        var s: usize = 0;
+        while (s < splat) : (s += 1) {
+            written += try writeBytesScan(self, self.out_buffer, last);
+        }
+
         return w.consume(written);
     }
 
@@ -807,4 +833,30 @@ test "PatchElementsOptions with custom values" {
     try std.testing.expectEqualStrings("evt-123", opts.event_id.?);
     try std.testing.expectEqual(5000, opts.retry_duration.?);
     try std.testing.expectEqual(NameSpace.svg, opts.namespace);
+}
+
+test "Message.drain honours write vector and splat" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var buf: Io.Writer.Allocating = .init(arena);
+    var msg: Message = .{};
+    msg.init(.patchElements, PatchElementsOptions{}, &buf.writer);
+    try msg.header();
+
+    // Two distinct slices + splat of the last: exercises the full drain loop
+    // (pre-fix drain only wrote data[0] and ignored splat).
+    var parts = [_][]const u8{ "A\n", "B" };
+    try msg.interface.writeSplatAll(parts[0..], 3);
+    try msg.end();
+
+    const out = buf.written();
+    try std.testing.expectEqualStrings(
+        \\event: datastar-patch-elements
+        \\data: elements A
+        \\data: elements BBB
+        \\
+        \\
+    , out);
 }

--- a/src/http_request.zig
+++ b/src/http_request.zig
@@ -55,7 +55,6 @@ pub fn NewSSESync(http: *HTTPRequest) !SSE {
 /// Return a new SSE object with custom options
 pub fn NewSSEOpt(http: *HTTPRequest, opt: SSEOptions) !SSE {
     const buf_size = if (opt.buffer_size != 0) opt.buffer_size else datastar.DEFAULT_BUFFER_SIZE;
-    const buf = try http.arena.alloc(u8, buf_size);
 
     // IF we are text/event-stream AND we have no content-length (chunked encoding)
     // THEN detach the request from the connection - because the browser will never queue
@@ -64,46 +63,77 @@ pub fn NewSSEOpt(http: *HTTPRequest, opt: SSEOptions) !SSE {
         http.detach = true;
     }
 
-    // need to create a BodyWriter on the heap, because we use it after this
-    // because this is on the arena owned by the handleConnection->request ...
-    // that means the handler needs to stay alive for as long we expect to keep
-    // using this bodyWriter. This has implications for pub/sub
-    const res = try http.arena.create(std.http.BodyWriter);
-    var headers: []const std.http.Header = try http.mergeHeaders(&.{
-        .{ .name = "content-type", .value = "text/event-stream; charset=UTF-8" },
-        .{ .name = "cache-control", .value = "no-cache" },
-    });
-    if (opt.extra_headers) |extras| {
-        headers = try http.mergeHeaders(extras);
+    // Always keep the SSE content-type / cache-control headers. Previously
+    // `extra_headers` *replaced* the merge result and dropped them.
+    const headers = try http.buildSseHeaders(opt.extra_headers);
+
+    const allocating_writer = blk: {
+        if (opt.buffer_size == 0) break :blk Io.Writer.Allocating.init(http.arena);
+        break :blk Io.Writer.Allocating.initCapacity(http.arena, buf_size) catch Io.Writer.Allocating.init(http.arena);
+    };
+
+    http.replied = true;
+
+    // One-shot (non-sync): defer the HTTP response until close() so we can emit
+    // Content-Length in a single respond() — avoids chunked framing + a second
+    // BodyWriter buffer for the common Datastar morph path.
+    if (!opt.sync) {
+        return .{
+            .stream = null,
+            .req = http.req,
+            .headers = headers,
+            .output_buffer = allocating_writer,
+            .buffer_size = opt.buffer_size,
+            .sync = false,
+            .io = http.io,
+            .start_time = Io.Clock.real.now(http.io),
+        };
     }
 
+    // Sync / long-lived: start a chunked stream immediately and flush headers.
+    const buf = try http.arena.alloc(u8, buf_size);
+    const res = try http.arena.create(std.http.BodyWriter);
     res.* = try http.req.respondStreaming(
         buf,
         .{ .respond_options = .{ .extra_headers = headers } },
     );
-    const allocating_writer = blk: {
-        if (opt.buffer_size == 0) break :blk Io.Writer.Allocating.init(http.arena);
-        break :blk Io.Writer.Allocating.initCapacity(http.arena, opt.buffer_size) catch Io.Writer.Allocating.init(http.arena);
-    };
-    if (opt.sync) {
-        try res.flush();
-    }
+    try res.flush();
 
-    http.replied = true;
     return .{
         .stream = res,
+        .req = null,
+        .headers = headers,
         .output_buffer = allocating_writer,
         .buffer_size = opt.buffer_size,
-        .sync = opt.sync,
+        .sync = true,
         .io = http.io,
         .start_time = Io.Clock.real.now(http.io),
     };
 }
 
 const default_headers = &[_]std.http.Header{
-    .{ .name = "Connection", .value = "keep-alive" },
+    // Do not force Connection: keep-alive — std.http.Server owns persistence
+    // and must be free to emit connection: close when the client asked for it.
     .{ .name = "X-Powered-By", .value = "datastar.zig" },
 };
+
+const sse_content_headers = [_]std.http.Header{
+    .{ .name = "content-type", .value = "text/event-stream; charset=UTF-8" },
+    .{ .name = "cache-control", .value = "no-cache" },
+};
+
+/// Build the header list for an SSE response: always include content-type /
+/// cache-control, optionally merge caller extras, then fold in defaults via
+/// mergeHeaders. Extracted so the merge-not-replace branch is unit-testable.
+pub fn buildSseHeaders(self: *HTTPRequest, extras: ?[]const std.http.Header) ![]const std.http.Header {
+    if (extras) |extra| {
+        const combined = try self.arena.alloc(std.http.Header, sse_content_headers.len + extra.len);
+        @memcpy(combined[0..sse_content_headers.len], &sse_content_headers);
+        @memcpy(combined[sse_content_headers.len..], extra);
+        return try self.mergeHeaders(combined);
+    }
+    return try self.mergeHeaders(&sse_content_headers);
+}
 
 /// use this to construct extra_headers when creating any response
 /// it will pull in self.extra_headers, and merge them with the new set
@@ -454,19 +484,98 @@ test "mergeHeaders" {
 
     const merged = try req.mergeHeaders(extra);
 
-    // defaults (2) + extra (1) = 3
-    // defaults are Connection and X-Powered-By
-    try std.testing.expectEqual(3, merged.len);
+    // defaults (1: X-Powered-By) + extra (1) = 2 — no forced Connection.
+    try std.testing.expectEqual(2, merged.len);
 
     var found_test_header = false;
+    var found_powered_by = false;
+    var found_connection = false;
 
     for (merged) |h| {
         if (std.mem.eql(u8, h.name, "X-Test") and std.mem.eql(u8, h.value, "True")) {
             found_test_header = true;
         }
+        if (std.mem.eql(u8, h.name, "X-Powered-By")) {
+            found_powered_by = true;
+        }
+        if (std.ascii.eqlIgnoreCase(h.name, "Connection")) {
+            found_connection = true;
+        }
     }
 
     try std.testing.expect(found_test_header);
+    try std.testing.expect(found_powered_by);
+    try std.testing.expect(!found_connection);
+}
+
+test "buildSseHeaders keeps content-type when extras present" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var req = HTTPRequest{
+        .req = undefined,
+        .io = undefined,
+        .arena = arena.allocator(),
+        .params = .{},
+    };
+
+    const headers = try req.buildSseHeaders(&.{
+        .{ .name = "Access-Control-Allow-Origin", .value = "*" },
+    });
+
+    var found_ct = false;
+    var found_cc = false;
+    var found_cors = false;
+    var found_powered_by = false;
+    for (headers) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "content-type") and
+            std.mem.indexOf(u8, h.value, "text/event-stream") != null) found_ct = true;
+        if (std.ascii.eqlIgnoreCase(h.name, "cache-control")) found_cc = true;
+        if (std.mem.eql(u8, h.name, "Access-Control-Allow-Origin")) found_cors = true;
+        if (std.mem.eql(u8, h.name, "X-Powered-By")) found_powered_by = true;
+    }
+    try std.testing.expect(found_ct);
+    try std.testing.expect(found_cc);
+    try std.testing.expect(found_cors);
+    try std.testing.expect(found_powered_by);
+}
+
+test "NewSSEOpt one-shot has no stream and keeps sync false" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // One-shot path only stores the request pointer until close(); a placeholder
+    // Request is enough to cover the !sync branch without respondStreaming.
+    var server_req: std.http.Server.Request = undefined;
+    var req = HTTPRequest{
+        .req = &server_req,
+        .io = std.testing.io,
+        .arena = arena.allocator(),
+        .params = .{},
+        .path = "/",
+        .method = .GET,
+    };
+
+    var sse = try NewSSEOpt(&req, .{
+        .extra_headers = &.{
+            .{ .name = "X-Test", .value = "1" },
+        },
+    });
+    defer sse.output_buffer.deinit();
+
+    try std.testing.expect(sse.stream == null);
+    try std.testing.expect(!sse.sync);
+    try std.testing.expect(req.replied);
+    try std.testing.expect(!req.detach);
+
+    var found_ct = false;
+    var found_x = false;
+    for (sse.headers) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "content-type")) found_ct = true;
+        if (std.mem.eql(u8, h.name, "X-Test")) found_x = true;
+    }
+    try std.testing.expect(found_ct);
+    try std.testing.expect(found_x);
 }
 
 test "readSignals GET" {

--- a/src/log.zig
+++ b/src/log.zig
@@ -27,6 +27,11 @@ slow_ms: u64 = 200, // 200ms
 fast_us: u64 = 20, // 20us
 
 pub fn info(log: Log, http: *HTTPRequest) void {
+    // format=.none is a mute switch. Historically only level=.none skipped
+    // logging in the router while format=.none still ran this path (clocks +
+    // std.log.info) every request — a ~3× throughput cliff on the bench.
+    if (log.format == .none) return;
+
     const elapsed_ns: i96 = http.timer.untilNow(http.io, std.Io.Clock.real).toNanoseconds();
     const c = log.theme.get();
     const payload_size: []const u8 = switch (http.method) {
@@ -65,13 +70,15 @@ pub fn debug(_: Log, comptime fmt: []const u8, args: anytype) void {
 }
 
 pub fn payload(self: Log, http: *HTTPRequest) void {
+    if (self.format == .none) return;
     if (http.req_payload) |p| {
         const c = self.theme.get();
         self.debug(" {t} >\n{s}{s}{s}", .{ http.method, c.debugColor(), p, c.reset });
     }
 }
 
-pub fn signals(_: Log, http: *HTTPRequest) void {
+pub fn signals(self: Log, http: *HTTPRequest) void {
+    if (self.format == .none) return;
     if (http.query()) |query_params| {
         if (http.method == .GET and query_params.len > 0) {
             const buf: []u8 = "";
@@ -126,4 +133,18 @@ pub fn formatTimeAlloc(http: *HTTPRequest) []u8 {
         sec,
         micros,
     }) catch "";
+}
+
+test "format=.none mutes info payload and signals without touching timer" {
+    // format=.none must return before reading http.timer / http.io — otherwise
+    // muted benches still pay a clock syscall every request.
+    var req: HTTPRequest = undefined;
+    req.method = .GET;
+    req.path = "/";
+    req.req_payload = "secret";
+    // Intentionally leave timer/io/arena undefined; mute must not touch them.
+    const log: Log = .{ .format = .none, .level = .all };
+    log.info(&req);
+    log.payload(&req);
+    log.signals(&req);
 }

--- a/src/router.zig
+++ b/src/router.zig
@@ -206,21 +206,19 @@ pub fn dispatch(self: *Router, http: *HTTPRequest) !void {
     }
 
     // TODO - remove this after its done in logging middleware instead
-    switch (log.level) {
-        .none => {},
-        else => {
-            log.info(http);
+    // format=.none mutes request logging (same as level=.none for the info path).
+    if (log.level != .none and log.format != .none) {
+        log.info(http);
 
-            switch (log.level) {
-                .payload => log.payload(http),
-                .signals => log.signals(http),
-                .all => {
-                    log.signals(http);
-                    log.payload(http);
-                },
-                else => {},
-            }
-        },
+        switch (log.level) {
+            .payload => log.payload(http),
+            .signals => log.signals(http),
+            .all => {
+                log.signals(http);
+                log.payload(http);
+            },
+            else => {},
+        }
     }
     if (!processed) {
         return http.respond("Method Not Allowed", .method_not_allowed);

--- a/src/server.zig
+++ b/src/server.zig
@@ -31,6 +31,9 @@ watch: bool = false,
 fd_limit: ?FDLimit = null,
 read_buffer_size: usize = 4 * 1024,
 write_buffer_size: usize = 4 * 1024,
+kernel_backlog: u31 = Io.net.default_kernel_backlog,
+/// Disable Nagle on accepted sockets (see Config.tcp_nodelay).
+tcp_nodelay: bool = true,
 
 group: Io.Group = .init,
 
@@ -43,11 +46,19 @@ pub const Config = struct {
     allocator: ?Allocator = null,
     watch: bool = false,
     fd_limit: ?FDLimit = null,
-    // Per-connection read/write buffers. Defaults of 4 KB keep the server lean
-    // for low/mid traffic. Bump these when responses are reliably much larger
-    // than 4 KB — fewer underlying writev/readv syscalls per request.
+    // Per-connection HTTP read/write buffers (Datastar-owned, not Io).
+    // Defaults stay lean (4 KiB). For ~8-11 KiB framed SSE morphs, 16 KiB
+    // often fits the response in one write drain; measure before bumping —
+    // 64 KiB has been observed to regress larger (~40 KiB+) morphs.
     read_buffer_size: usize = 4 * 1024,
     write_buffer_size: usize = 4 * 1024,
+    /// Forwarded to `Io.net.ListenOptions.kernel_backlog` (Io default: 128).
+    /// Raise under high accept fan-in (e.g. wrk -c400 cold bursts).
+    kernel_backlog: u31 = Io.net.default_kernel_backlog,
+    /// Set TCP_NODELAY on each accepted socket. Default true — without it,
+    /// small request/response pairs stall ~40ms on Nagle + delayed ACK
+    /// (Go/Kestrel enable this by default). Set false only if you need Nagle.
+    tcp_nodelay: bool = true,
 };
 
 // FD limit configuration
@@ -76,7 +87,10 @@ pub fn init(process_init: std.process.Init, config: Config) !*Server {
 
     self.* = .{
         .process_init = process_init,
-        .server = try address.listen(io, .{ .reuse_address = true }),
+        .server = try address.listen(io, .{
+            .reuse_address = true,
+            .kernel_backlog = config.kernel_backlog,
+        }),
         .router = undefined,
         .log = config.log,
         .io = io,
@@ -86,6 +100,8 @@ pub fn init(process_init: std.process.Init, config: Config) !*Server {
         .fd_limit = config.fd_limit,
         .read_buffer_size = config.read_buffer_size,
         .write_buffer_size = config.write_buffer_size,
+        .kernel_backlog = config.kernel_backlog,
+        .tcp_nodelay = config.tcp_nodelay,
     };
     errdefer self.arena.deinit();
     self.router = try Router.init(self.arena.allocator());
@@ -145,6 +161,13 @@ fn nonBlocking(conn: Io.net.Stream) !void {
 fn handleConnection(self: *Server, conn: Io.net.Stream) Io.Cancelable!void {
     defer conn.close(self.io);
 
+    if (self.tcp_nodelay) {
+        // Avoid Nagle + delayed-ACK ~40ms stalls on small request/response pairs.
+        // Large payloads hide this; small SSE morphs do not.
+        const one: c_int = 1;
+        posix.setsockopt(conn.socket.handle, posix.IPPROTO.TCP, posix.TCP.NODELAY, std.mem.asBytes(&one)) catch {};
+    }
+
     // Outer arena lives for the whole connection. Holds the connection-scoped
     // read/write buffers (sized by config) so we can have runtime-configurable
     // sizes without a stack array of runtime length.
@@ -177,7 +200,11 @@ fn handleConnection(self: *Server, conn: Io.net.Stream) Io.Cancelable!void {
             .params = .{},
             .path = handler_arena.allocator().dupe(u8, request.head.target) catch return error.Canceled,
             .method = request.head.method,
-            .timer = .now(self.io, std.Io.Clock.real),
+            // Only pay for a clock read when request logging will use it.
+            .timer = if (self.log.level != .none and self.log.format != .none)
+                .now(self.io, std.Io.Clock.real)
+            else
+                undefined,
             .log = self.log,
         };
 
@@ -436,4 +463,12 @@ test "urlDecode handles mixed encoding" {
 
     const decoded = try datastar.urlDecode(arena.allocator(), "foo+bar%3Dbaz");
     try std.testing.expectEqualStrings("foo bar=baz", decoded);
+}
+
+test "Config defaults keep lean buffers and enable tcp_nodelay" {
+    const cfg = Config{};
+    try std.testing.expectEqual(@as(usize, 4 * 1024), cfg.read_buffer_size);
+    try std.testing.expectEqual(@as(usize, 4 * 1024), cfg.write_buffer_size);
+    try std.testing.expectEqual(Io.net.default_kernel_backlog, cfg.kernel_backlog);
+    try std.testing.expect(cfg.tcp_nodelay);
 }


### PR DESCRIPTION
## Summary
- Set `TCP_NODELAY` on accept via `Config.tcp_nodelay` (default `true`; overridable). Matches Go/Kestrel defaults; without it, small SSE morphs stall ~40ms on Nagle + delayed ACK.
- Make `log.format = .none` actually mute request logging, and skip the per-request timer when logging is muted.
- Merge `NewSSEOpt.extra_headers` with the SSE content-type/cache-control headers; stop forcing `Connection: keep-alive`.
- Non-sync SSE responds once with Content-Length via `respond()` instead of chunked framing + a second body copy; sync/long-lived SSE still streams chunked. Fixes `Message.drain` to honor the full write vector + splat.
- Expose `Config.kernel_backlog` (forwarded to `Io.net.ListenOptions`, default unchanged at 128) and document when to raise the existing 4 KiB read/write buffer sizes for ~8-11 KiB morphs — defaults left lean.

**Out of scope (measured, not beneficial):** a bulk `framePatchElements` / `sendRaw` path was A/B’d against the existing `Message` framer on a 9900X (`wrk -t12 -c400 -d5s`, two passes). The Message path won ~10% on ~11 KiB card morphs and ~6% on ~40 KiB page morphs; preframed was flat. Left out of this PR.

Closes #13

## Test plan
- [ ] `zig build test` — 58 tests pass (new coverage below)
- [ ] Valgrind (linux-x86_64, `-mcpu=baseline`): both test binaries `ERROR SUMMARY: 0 errors` (canary UAF confirmed detector fires first)
- [ ] Non-sync SSE response carries `content-length` (not chunked) and still sends `content-type: text/event-stream`
- [ ] `extra_headers` no longer drops content-type / cache-control
- [ ] `format = .none` emits no per-request log lines
- [ ] `Config.tcp_nodelay = false` leaves Nagle enabled (opt-out works)

### New unit tests (branch coverage)
- `Config defaults keep lean buffers and enable tcp_nodelay`
- `format=.none mutes info payload and signals without touching timer`
- `buildSseHeaders keeps content-type when extras present`
- `mergeHeaders` asserts no forced `Connection` header
- `NewSSEOpt one-shot has no stream and keeps sync false`
- `Message.drain honours write vector and splat`

## AI disclosure
This change was developed with assistance from an AI coding agent (Cursor). I specified the goals and constraints, reviewed every diff, ran / directed the benchmarks that motivate the defaults, and remain responsible for the correctness of the patch. No AI-generated content should be treated as unaudited.