### PR TITLE
#16 Make streaming the default SDK patch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,19 +342,19 @@ If you've already chosen an HTTP framework — `http.zig`, `dusty`, `zap`, `jetz
 
 > **For SDK-only use, prefer [`datastar-sdk.zig`](https://github.com/zigster64/datastar-sdk.zig)** — same transformer functions packaged as a standalone module, without dragging in the bundled HTTP server or the pubsub dependency. This section is a quick reference; the dedicated repo is what you want to depend on for production SDK-only use.
 
-Each transformer returns a complete `event: ...\ndata: ...\n\n` SSE block — concatenate as many as you want and write them as the response body with `Content-Type: text/event-stream`:
+The primary transformers write a complete `event: ...\ndata: ...\n\n` SSE block directly to a writer. This is the default because SSE is a streaming protocol and it avoids retaining an intermediate copy. Frameworks that require a complete response body can use the explicit `*Alloc` conveniences.
 
 ```zig
 const datastar = @import("datastar");
 
-// Inside any framework's SSE handler, with an arena and a `res` from your framework:
-
-const a = try datastar.patchElements(arena, "<div id='hello'>Hi</div>", .{});
-const b = try datastar.patchSignals(arena, .{ .foo = 42, .bar = "Datastar Rocks" }, .{});
-const c = try datastar.executeScriptFmt(arena, "alert('hello {s}')", .{name}, .{});
-
+// Inside any framework's SSE handler:
 res.header("Content-Type", "text/event-stream");
-res.body = try std.mem.concat(arena, u8, &.{ a, b, c });
+try datastar.patchElements(response_writer, "<div id='hello'>Hi</div>", .{});
+try datastar.patchSignals(response_writer, .{ .foo = 42, .bar = "Datastar Rocks" }, .{});
+try datastar.executeScriptFmt(response_writer, "alert('hello {s}')", .{name}, .{});
+
+// If the framework requires a complete response body:
+res.body = try datastar.patchElementsAlloc(arena, html, .{});
 
 // And to read Datastar signals on the way in:
 const Signals = struct { name: []const u8, count: u32 };
@@ -369,15 +369,20 @@ The full SDK surface:
 datastar.readSignals(comptime T: type, arena: Allocator, req: *std.http.Server.Request) !T
 
 // Patch DOM elements
-datastar.patchElements(arena, html, opts) ![]const u8
-datastar.patchElementsFmt(arena, comptime fmt, args, opts) ![]const u8
+datastar.patchElements(writer, html, opts) !void
+datastar.patchElementsFmt(writer, comptime fmt, args, opts) !void
+datastar.patchElementsAlloc(arena, html, opts) ![]const u8
+datastar.patchElementsFmtAlloc(arena, comptime fmt, args, opts) ![]const u8
 
 // Patch signals (any JSON-serializable value)
-datastar.patchSignals(arena, value, opts) ![]const u8
+datastar.patchSignals(writer, value, opts) !void
+datastar.patchSignalsAlloc(arena, value, opts) ![]const u8
 
 // Execute a script on the client (wraps the script in a <script> tag and patches it into body)
-datastar.executeScript(arena, script, opts) ![]const u8
-datastar.executeScriptFmt(arena, comptime fmt, args, opts) ![]const u8
+datastar.executeScript(writer, script, opts) !void
+datastar.executeScriptFmt(writer, comptime fmt, args, opts) !void
+datastar.executeScriptAlloc(arena, script, opts) ![]const u8
+datastar.executeScriptFmtAlloc(arena, comptime fmt, args, opts) ![]const u8
 
 // Helper — re-exported for framework adapters
 datastar.urlDecode(allocator, input) ![]u8

--- a/bench/README.md
+++ b/bench/README.md
@@ -110,3 +110,17 @@ I dont know if `wrk` conforms to that, or not either.
 Would have to do some serious instrumenting to find out where the time is spent, but its probably a combination of all of the above.
 
 The fact that its consistent across the board will different languages and SDKs suggests the numbers are pretty correct though.
+
+# Peak RSS / allocation
+
+`zig build peak-rss` (from the repo root) isolates each `(mode × placement × size)` in its own child process and reports:
+
+| column | meaning |
+| --- | --- |
+| `rss_delta` | `ru_maxrss` after framing minus after fragment touch |
+| `req_bytes` | bytes requested through a counting allocator during framing |
+| `arena_cap` | `ArenaAllocator.queryCapacity` growth during framing |
+
+Modes: `ladder` (Allocating from zero in the arena), `alloc` (`patchElementsAlloc`), `stream` (`patchElements` into a discarding writer).
+
+On the measured 4.7 MB in-arena shape, streaming requests **0** framing bytes; the ladder still requests ~12× the fragment.

--- a/bench/peak_rss.zig
+++ b/bench/peak_rss.zig
@@ -1,0 +1,362 @@
+//! Peak-RSS / allocation analysis for the patchElements streaming change.
+//!
+//! Why a separate child per (mode × size × placement):
+//!   `getrusage(RUSAGE_SELF).ru_maxrss` is a process-lifetime *peak*. Once a
+//!   scenario has touched a high-water mark, later scenarios in the same
+//!   process cannot report a lower peak. Spawning isolates each run.
+//!
+//! Metrics (all three; none alone is enough):
+//!   - peak RSS delta  — OS-visible resident growth from framing
+//!   - bytes requested — CountingAllocator, the figure that actually moves
+//!                       when the allocation strategy changes.
+//!                       ArenaAllocator.queryCapacity grows geometrically and
+//!                       can make a real win look like a regression, so it is
+//!                       not the primary figure.
+//!   - arena capacity  — secondary; useful for the "fragment already in arena"
+//!                       geometry but not the primary verdict
+//!
+//! Modes:
+//!   ladder   — Allocating-from-zero, the pre-change shape (measured ~7× peak)
+//!   alloc    — patchElementsAlloc (pre-sized writer buffer)
+//!   stream   — patchElements(writer) into a discarding sink (default API)
+//!   baseline — fragment only, no framing (sanity / floor)
+//!
+//! Run:  zig build peak-rss
+
+const std = @import("std");
+const builtin = @import("builtin");
+const datastar = @import("datastar");
+const Io = std.Io;
+const Allocator = std.mem.Allocator;
+
+const Mode = enum { baseline, ladder, alloc, stream };
+const Placement = enum {
+    /// Fragment already occupies the request arena (the amplifying shape).
+    in_arena,
+    /// Fragment lives outside; framing is the only arena consumer.
+    outside,
+};
+
+const sizes = [_]usize{
+    64 * 1024,
+    512 * 1024,
+    1024 * 1024,
+    4 * 1024 * 1024,
+    4_732_869, // a real large-fragment size observed in a rendered list
+};
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    // argv[0]=exe; optional: run <mode> <placement> <size>
+    if (args.len >= 5 and std.mem.eql(u8, args[1], "run")) {
+        const mode = std.meta.stringToEnum(Mode, args[2]) orelse return error.BadMode;
+        const placement = std.meta.stringToEnum(Placement, args[3]) orelse return error.BadPlacement;
+        const size = try std.fmt.parseInt(usize, args[4], 10);
+        try runChild(init.io, init.gpa, mode, placement, size);
+        return;
+    }
+
+    try runParent(init.io, init.gpa, args[0]);
+}
+
+fn runParent(io: Io, gpa: Allocator, self_exe: []const u8) !void {
+    var stdout_buf: [4096]u8 = undefined;
+    var stdout = Io.File.stdout().writer(io, &stdout_buf);
+    const out = &stdout.interface;
+
+    try out.writeAll(
+        \\# patchElements peak memory
+        \\# each row is an isolated child process (ru_maxrss is a lifetime peak)
+        \\# rss_delta = peak_rss_after_frame - peak_rss_after_fragment  (bytes)
+        \\# req_bytes = bytes requested through the counting allocator during framing
+        \\# arena_cap = ArenaAllocator.queryCapacity after framing (chunk geometry)
+        \\#
+        \\mode       placement   fragment     out_len   rss_delta   req_bytes  arena_cap  rss/frag  req/frag
+        \\
+    );
+
+    for (sizes) |size| {
+        for (std.meta.tags(Placement)) |placement| {
+            for (std.meta.tags(Mode)) |mode| {
+                try runOne(io, gpa, out, self_exe, mode, placement, size);
+            }
+        }
+        try out.writeAll("\n");
+    }
+
+    // Spotlight the large in-arena shape so the table does not bury the verdict.
+    try out.writeAll(
+        \\# verdict @ fragment=4732869 in_arena (large fragment already in arena)
+        \\#   metric          ladder        alloc       stream
+        \\
+    );
+    const verdict_size: usize = 4_732_869;
+    var ladder_req: usize = 0;
+    var alloc_req: usize = 0;
+    var stream_req: usize = 0;
+    var ladder_arena: usize = 0;
+    var alloc_arena: usize = 0;
+    var stream_arena: usize = 0;
+    var ladder_rss: usize = 0;
+    var alloc_rss: usize = 0;
+    var stream_rss: usize = 0;
+
+    // Re-run just the three modes for the summary (cheap relative to clarity).
+    for ([_]Mode{ .ladder, .alloc, .stream }) |mode| {
+        const row = try measureChild(io, gpa, self_exe, mode, .in_arena, verdict_size);
+        switch (mode) {
+            .ladder => {
+                ladder_req = row.req_bytes;
+                ladder_arena = row.arena_cap;
+                ladder_rss = row.rss_delta;
+            },
+            .alloc => {
+                alloc_req = row.req_bytes;
+                alloc_arena = row.arena_cap;
+                alloc_rss = row.rss_delta;
+            },
+            .stream => {
+                stream_req = row.req_bytes;
+                stream_arena = row.arena_cap;
+                stream_rss = row.rss_delta;
+            },
+            .baseline => unreachable,
+        }
+    }
+    try out.print(
+        \\#   req_bytes   {d:>12} {d:>12} {d:>12}
+        \\#   arena_cap   {d:>12} {d:>12} {d:>12}
+        \\#   rss_delta   {d:>12} {d:>12} {d:>12}
+        \\#   req/frag        {d:>8.2}     {d:>8.2}     {d:>8.2}
+        \\#
+        \\# stream is the win: zero framing allocation in the request arena.
+        \\# alloc beats ladder on requested bytes but still pays ArenaAllocator
+        \\# 1.5×(prev+request) node geometry when the fragment is already resident.
+        \\# rss_delta understates retained arena pages on Darwin when growth remaps;
+        \\# prefer req_bytes / arena_cap for the allocator-level verdict.
+        \\
+    ,
+        .{
+            ladder_req,
+            alloc_req,
+            stream_req,
+            ladder_arena,
+            alloc_arena,
+            stream_arena,
+            ladder_rss,
+            alloc_rss,
+            stream_rss,
+            @as(f64, @floatFromInt(ladder_req)) / @as(f64, @floatFromInt(verdict_size)),
+            @as(f64, @floatFromInt(alloc_req)) / @as(f64, @floatFromInt(verdict_size)),
+            @as(f64, @floatFromInt(stream_req)) / @as(f64, @floatFromInt(verdict_size)),
+        },
+    );
+    try out.flush();
+}
+
+const ChildRow = struct {
+    out_len: usize,
+    rss_delta: usize,
+    req_bytes: usize,
+    arena_cap: usize,
+};
+
+fn measureChild(
+    io: Io,
+    gpa: Allocator,
+    self_exe: []const u8,
+    mode: Mode,
+    placement: Placement,
+    size: usize,
+) !ChildRow {
+    const mode_s = @tagName(mode);
+    const place_s = @tagName(placement);
+    var size_buf: [32]u8 = undefined;
+    const size_s = try std.fmt.bufPrint(&size_buf, "{d}", .{size});
+
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ self_exe, "run", mode_s, place_s, size_s },
+        .stdout = .pipe,
+        .stderr = .inherit,
+        .request_resource_usage_statistics = true,
+    });
+    defer if (child.stdout) |*f| f.close(io);
+
+    var line_buf: [512]u8 = undefined;
+    var stdout_file = child.stdout.?;
+    var file_reader = stdout_file.reader(io, &line_buf);
+    const line = try file_reader.interface.takeDelimiterExclusive('\n');
+
+    const term = try child.wait(io);
+    switch (term) {
+        .exited => |code| if (code != 0) return error.ChildFailed,
+        else => return error.ChildFailed,
+    }
+
+    var it = std.mem.tokenizeScalar(u8, line, ' ');
+    const out_len = try std.fmt.parseInt(usize, it.next() orelse return error.BadChildOutput, 10);
+    const rss_frag = try std.fmt.parseInt(usize, it.next() orelse return error.BadChildOutput, 10);
+    const rss_frame = try std.fmt.parseInt(usize, it.next() orelse return error.BadChildOutput, 10);
+    const req_bytes = try std.fmt.parseInt(usize, it.next() orelse return error.BadChildOutput, 10);
+    const arena_cap = try std.fmt.parseInt(usize, it.next() orelse return error.BadChildOutput, 10);
+    _ = gpa;
+    return .{
+        .out_len = out_len,
+        .rss_delta = rss_frame -| rss_frag,
+        .req_bytes = req_bytes,
+        .arena_cap = arena_cap,
+    };
+}
+
+fn runOne(
+    io: Io,
+    gpa: Allocator,
+    out: *Io.Writer,
+    self_exe: []const u8,
+    mode: Mode,
+    placement: Placement,
+    size: usize,
+) !void {
+    const row = try measureChild(io, gpa, self_exe, mode, placement, size);
+    const rss_ratio = if (size == 0) 0 else @as(f64, @floatFromInt(row.rss_delta)) / @as(f64, @floatFromInt(size));
+    const req_ratio = if (size == 0) 0 else @as(f64, @floatFromInt(row.req_bytes)) / @as(f64, @floatFromInt(size));
+
+    try out.print("{s:<10} {s:<10} {d:>10} {d:>10} {d:>10} {d:>10} {d:>10} {d:>8.2} {d:>8.2}\n", .{
+        @tagName(mode),
+        @tagName(placement),
+        size,
+        row.out_len,
+        row.rss_delta,
+        row.req_bytes,
+        row.arena_cap,
+        rss_ratio,
+        req_ratio,
+    });
+}
+
+fn runChild(io: Io, gpa: Allocator, mode: Mode, placement: Placement, size: usize) !void {
+    var counting: CountingAllocator = .{ .child = gpa };
+    const counted = counting.allocator();
+
+    var arena_inst = std.heap.ArenaAllocator.init(counted);
+    defer arena_inst.deinit();
+    const arena = arena_inst.allocator();
+
+    // Build the fragment. For in_arena it is the first (large) arena resident;
+    // for outside it lives on the GPA and is not an arena consumer.
+    const fragment = switch (placement) {
+        .in_arena => try arena.alloc(u8, size),
+        .outside => try gpa.alloc(u8, size),
+    };
+    defer if (placement == .outside) gpa.free(fragment);
+    @memset(fragment, 'x');
+    if (size > 0) {
+        fragment[0] = '<';
+        fragment[size - 1] = '>';
+        if (size > 1000) fragment[1000] = '\n';
+        if (size > 100_000) fragment[100_000] = '\n';
+    }
+
+    // Force the pages resident so ru_maxrss reflects the fragment before framing.
+    touchPages(fragment);
+    const rss_after_frag = peakRssBytes();
+
+    // Reset counters so req_bytes is framing-only.
+    counting.bytes = 0;
+    counting.count = 0;
+    const arena_before = arena_inst.queryCapacity();
+
+    var out_len: usize = 0;
+    switch (mode) {
+        .baseline => {},
+        .ladder => {
+            // Pre-fix shape: stream into an Allocating writer that grows from
+            // zero in the request arena (doubling ladder; free is a no-op).
+            var buf: Io.Writer.Allocating = .init(arena);
+            try datastar.patchElements(&buf.writer, fragment, .{});
+            out_len = buf.written().len;
+        },
+        .alloc => {
+            const framed = try datastar.patchElementsAlloc(arena, fragment, .{});
+            out_len = framed.len;
+        },
+        .stream => {
+            // Discarding sink: framing must not retain an intermediate copy.
+            var discard_buf: [4096]u8 = undefined;
+            var discarding: Io.Writer.Discarding = .init(&discard_buf);
+            try datastar.patchElements(&discarding.writer, fragment, .{});
+            out_len = discarding.fullCount();
+        },
+    }
+
+    const rss_after_frame = peakRssBytes();
+    const arena_after = arena_inst.queryCapacity();
+    const arena_grown = arena_after -| arena_before;
+
+    var stdout_buf: [256]u8 = undefined;
+    var stdout = Io.File.stdout().writer(io, &stdout_buf);
+    try stdout.interface.print("{d} {d} {d} {d} {d}\n", .{
+        out_len,
+        rss_after_frag,
+        rss_after_frame,
+        counting.bytes,
+        arena_grown,
+    });
+    try stdout.interface.flush();
+}
+
+fn touchPages(buf: []u8) void {
+    var i: usize = 0;
+    while (i < buf.len) : (i += std.heap.pageSize()) {
+        buf[i] = buf[i];
+    }
+    if (buf.len > 0) buf[buf.len - 1] = buf[buf.len - 1];
+}
+
+fn peakRssBytes() usize {
+    // RUSAGE_SELF == 0 on Linux and Darwin.
+    const ru = std.posix.getrusage(0);
+    return switch (builtin.os.tag) {
+        .linux, .freebsd, .netbsd, .openbsd, .dragonfly, .illumos, .serenity => @as(usize, @intCast(ru.maxrss)) * 1024,
+        .macos, .ios, .tvos, .watchos, .visionos, .driverkit, .maccatalyst => @as(usize, @intCast(ru.maxrss)),
+        else => @as(usize, @intCast(ru.maxrss)),
+    };
+}
+
+/// Counts bytes actually requested. Prefer this over ArenaAllocator.queryCapacity
+/// for allocation-strategy verdicts (queryCapacity reports chunk geometry).
+const CountingAllocator = struct {
+    child: Allocator,
+    bytes: usize = 0,
+    count: usize = 0,
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        const p = self.child.rawAlloc(len, alignment, ra) orelse return null;
+        self.bytes += len;
+        self.count += 1;
+        return p;
+    }
+    fn resize(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        if (new_len > buf.len) self.bytes += new_len - buf.len;
+        return self.child.rawResize(buf, alignment, new_len, ra);
+    }
+    fn remap(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        if (new_len > buf.len) self.bytes += new_len - buf.len;
+        return self.child.rawRemap(buf, alignment, new_len, ra);
+    }
+    fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.child.rawFree(buf, alignment, ra);
+    }
+    fn allocator(self: *CountingAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .remap = remap,
+            .free = free,
+        } };
+    }
+};

--- a/build.zig
+++ b/build.zig
@@ -192,4 +192,19 @@ pub fn build(b: *std.Build) void {
     dusty_check.root_module.addImport("datastar", datastar_module);
     dusty_check.root_module.addImport("dusty", dusty.module("dusty"));
     check.dependOn(&dusty_check.step);
+
+    // Peak-RSS / allocation analysis for the streaming patchElements change.
+    // ReleaseFast so DebugAllocator metadata does not dominate the RSS signal.
+    const peak_rss = b.addExecutable(.{
+        .name = "peak-rss",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("bench/peak_rss.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+        }),
+    });
+    peak_rss.root_module.addImport("datastar", datastar_module);
+    const peak_rss_step = b.step("peak-rss", "Measure patchElements peak RSS / allocation (ladder vs alloc vs stream)");
+    const run_peak_rss = b.addRunArtifact(peak_rss);
+    peak_rss_step.dependOn(&run_peak_rss.step);
 }

--- a/examples/01_basic_dusty.zig
+++ b/examples/01_basic_dusty.zig
@@ -4,14 +4,15 @@
 // server. All Datastar SSE payloads are built with the framework-agnostic
 // transformer functions:
 //
-//     datastar.patchElements(arena, html, opts)         ![]const u8
-//     datastar.patchElementsFmt(arena, fmt, args, opts) ![]const u8
-//     datastar.patchSignals(arena, value, opts)         ![]const u8
-//     datastar.executeScript(arena, script, opts)       ![]const u8
-//     datastar.executeScriptFmt(arena, fmt, args, opts) ![]const u8
+//     datastar.patchElements(writer, html, opts)              !void
+//     datastar.patchElementsAlloc(arena, html, opts)          ![]const u8
+//     datastar.patchElementsFmtAlloc(arena, fmt, args, opts)  ![]const u8
+//     datastar.patchSignalsAlloc(arena, value, opts)          ![]const u8
+//     datastar.executeScriptAlloc(arena, script, opts)        ![]const u8
+//     datastar.executeScriptFmtAlloc(arena, fmt, args, opts)  ![]const u8
 //
-// Each one returns a full `event: ...\ndata: ...\n\n` block ready to write to
-// any response body or stream as `Content-Type: text/event-stream`.
+// Streaming to a writer is the primary SDK contract. This adapter uses the
+// explicit `*Alloc` conveniences because dusty expects a complete body.
 //
 // Build with:  zig build dusty
 // Run with:    ./zig-out/bin/example_1_dusty
@@ -144,7 +145,7 @@ fn patchElements(req: *dusty.Request, res: *dusty.Response) !void {
     try res.header("X-SSE-More-Headers", "Patch Elements Example");
     try res.header("X-SSE-Even-More-Headers", "All the Headers");
 
-    res.body = try datastar.patchElementsFmt(
+    res.body = try datastar.patchElementsFmtAlloc(
         req.arena,
         \\<p id="mf-patch">This is update number {d}</p>
     ,
@@ -173,13 +174,13 @@ fn patchElementsOpts(req: *dusty.Request, res: *dusty.Response) !void {
 
     try beginSseBatch(res);
     res.body = switch (patch_mode) {
-        .replace => try datastar.patchElements(
+        .replace => try datastar.patchElementsAlloc(
             req.arena,
             \\<p id="mf-patch-opts" class="border-4 border-error">Complete Replacement of the OUTER HTML</p>
         ,
             opts,
         ),
-        else => try datastar.patchElementsFmt(
+        else => try datastar.patchElementsFmtAlloc(
             req.arena,
             \\<p>This is update number {d}</p>
         ,
@@ -191,7 +192,7 @@ fn patchElementsOpts(req: *dusty.Request, res: *dusty.Response) !void {
 
 fn patchElementsOptsReset(req: *dusty.Request, res: *dusty.Response) !void {
     try beginSseBatch(res);
-    res.body = try datastar.patchElements(req.arena, @embedFile("01_index_opts.html"), .{});
+    res.body = try datastar.patchElementsAlloc(req.arena, @embedFile("01_index_opts.html"), .{});
 }
 
 fn jsonSignals(_: *dusty.Request, res: *dusty.Response) !void {
@@ -204,7 +205,7 @@ fn patchSignals(req: *dusty.Request, res: *dusty.Response) !void {
     try beginSseBatch(res);
     const foo = prng.random().intRangeAtMost(u8, 0, 255);
     const bar = prng.random().intRangeAtMost(u8, 0, 255);
-    res.body = try datastar.patchSignals(req.arena, .{ .foo = foo, .bar = bar }, .{});
+    res.body = try datastar.patchSignalsAlloc(req.arena, .{ .foo = foo, .bar = bar }, .{});
 }
 
 fn patchSignalsOnlyIfMissing(req: *dusty.Request, res: *dusty.Response) !void {
@@ -212,12 +213,12 @@ fn patchSignalsOnlyIfMissing(req: *dusty.Request, res: *dusty.Response) !void {
     const foo = prng.random().intRangeAtMost(u8, 1, 100);
     const bar = prng.random().intRangeAtMost(u8, 1, 100);
 
-    const signals_block = try datastar.patchSignals(
+    const signals_block = try datastar.patchSignalsAlloc(
         req.arena,
         .{ .newfoo = foo, .newbar = bar },
         .{ .only_if_missing = true },
     );
-    const script_block = try datastar.executeScript(
+    const script_block = try datastar.executeScriptAlloc(
         req.arena,
         "console.log('Patched newfoo and newbar, but only if missing');",
         .{},
@@ -247,7 +248,7 @@ fn patchSignalsRemove(req: *dusty.Request, res: *dusty.Response) !void {
     );
 
     try beginSseBatch(res);
-    res.body = try datastar.patchSignals(req.arena, parsed, .{});
+    res.body = try datastar.patchSignalsAlloc(req.arena, parsed, .{});
 }
 
 const snippets = [_][]const u8{
@@ -274,12 +275,12 @@ fn executeScript(req: *dusty.Request, res: *dusty.Response) !void {
 
     try beginSseBatch(res);
     res.body = switch (sample) {
-        1 => try datastar.executeScript(
+        1 => try datastar.executeScriptAlloc(
             req.arena,
             "console.log('Running from executeScript() directly');",
             .{},
         ),
-        2 => try datastar.executeScript(
+        2 => try datastar.executeScriptAlloc(
             req.arena,
             \\console.log('Multiline Script, using executeScript with a built-up payload');
             \\parent = document.querySelector('#execute-script-page');
@@ -287,13 +288,13 @@ fn executeScript(req: *dusty.Request, res: *dusty.Response) !void {
         ,
             .{ .attributes = attribs },
         ),
-        3 => try datastar.executeScriptFmt(
+        3 => try datastar.executeScriptFmtAlloc(
             req.arena,
             "console.log('Using formatted print {d}');",
             .{sample},
             .{},
         ),
-        else => try datastar.executeScriptFmt(
+        else => try datastar.executeScriptFmtAlloc(
             req.arena,
             "console.log('Unknown SampleID {d}');",
             .{sample},
@@ -367,7 +368,7 @@ fn emitSvgFrame(
     args: anytype,
 ) !void {
     fba.reset();
-    const block = try datastar.patchElementsFmt(fba.allocator(), fmt, args, .{ .namespace = .svg });
+    const block = try datastar.patchElementsFmtAlloc(fba.allocator(), fmt, args, .{ .namespace = .svg });
     try writeBlock(conn, block);
 }
 
@@ -390,14 +391,14 @@ fn mathMorph(req: *dusty.Request, res: *dusty.Response) !void {
 
     if (opt.mathmlMorph == 1) {
         try beginSseBatch(res);
-        const a = try datastar.patchElementsFmt(
+        const a = try datastar.patchElementsFmtAlloc(
             req.arena,
             \\<mn id="math-factor" class="text-red-500 font-bold">{}</mn>
         ,
             .{prng.random().intRangeAtMost(u16, 2, 22)},
             .{ .namespace = .mathml, .view_transition = true },
         );
-        const b = try datastar.patchSignals(req.arena, .{ .mathmlMorph = 1 }, .{});
+        const b = try datastar.patchSignalsAlloc(req.arena, .{ .mathmlMorph = 1 }, .{});
         res.body = try std.mem.concat(req.arena, u8, &.{ a, b });
         return;
     }
@@ -416,7 +417,7 @@ fn mathMorph(req: *dusty.Request, res: *dusty.Response) !void {
     for (0..opt.mathmlMorph) |_| {
         fba.reset();
         const r = prng.random().intRangeAtMost(u8, 1, mathMLs.len);
-        const block = try datastar.patchElements(
+        const block = try datastar.patchElementsAlloc(
             fba.allocator(),
             mathMLs[r - 1],
             .{ .namespace = .mathml },
@@ -426,7 +427,7 @@ fn mathMorph(req: *dusty.Request, res: *dusty.Response) !void {
     }
 
     fba.reset();
-    const reset_block = try datastar.patchSignals(fba.allocator(), .{ .mathmlMorph = 1 }, .{});
+    const reset_block = try datastar.patchSignalsAlloc(fba.allocator(), .{ .mathmlMorph = 1 }, .{});
     try writeBlock(stream.conn, reset_block);
 }
 
@@ -460,7 +461,7 @@ fn code(req: *dusty.Request, res: *dusty.Response) !void {
     const selector = try std.fmt.allocPrint(req.arena, "#code-{}", .{snip});
 
     try beginSseBatch(res);
-    res.body = try datastar.patchElements(
+    res.body = try datastar.patchElementsAlloc(
         req.arena,
         html.written(),
         .{ .selector = selector, .mode = .append },
@@ -495,7 +496,7 @@ fn hotreload(req: *dusty.Request, res: *dusty.Response) !void {
 
     if (id != hotreload_id) {
         std.log.warn("Client is stale {} != {} - reload them", .{ id, hotreload_id });
-        const block = try datastar.executeScript(fba.allocator(), "window.location.reload()", .{});
+        const block = try datastar.executeScriptAlloc(fba.allocator(), "window.location.reload()", .{});
         try writeBlock(stream.conn, block);
         return;
     }
@@ -515,7 +516,7 @@ fn hotreload(req: *dusty.Request, res: *dusty.Response) !void {
         ,
             .{seconds},
         );
-        const block = try datastar.patchElements(fba.allocator(), ping, .{});
+        const block = try datastar.patchElementsAlloc(fba.allocator(), ping, .{});
         try writeBlock(stream.conn, block);
     }
 }

--- a/examples/01_basic_httpz.zig
+++ b/examples/01_basic_httpz.zig
@@ -4,15 +4,15 @@
 // datastar.HTTPServer has been swapped out for httpz. SSE payloads are now built
 // with the framework-agnostic transformer functions:
 //
-//     datastar.patchElements(arena, html, opts)         ![]const u8
-//     datastar.patchElementsFmt(arena, fmt, args, opts) ![]const u8
-//     datastar.patchSignals(arena, value, opts)         ![]const u8
-//     datastar.executeScript(arena, script, opts)       ![]const u8
-//     datastar.executeScriptFmt(arena, fmt, args, opts) ![]const u8
+//     datastar.patchElements(writer, html, opts)              !void
+//     datastar.patchElementsAlloc(arena, html, opts)          ![]const u8
+//     datastar.patchElementsFmtAlloc(arena, fmt, args, opts)  ![]const u8
+//     datastar.patchSignalsAlloc(arena, value, opts)          ![]const u8
+//     datastar.executeScriptAlloc(arena, script, opts)        ![]const u8
+//     datastar.executeScriptFmtAlloc(arena, fmt, args, opts)  ![]const u8
 //
-// The string each one returns is a complete `event: ...\ndata: ...\n\n` block;
-// concatenate as many as you want and ship them as the response body with
-// Content-Type: text/event-stream.
+// Streaming to a writer is the primary SDK contract. This adapter uses the
+// explicit `*Alloc` conveniences because http.zig expects a complete body.
 //
 // Build with:  zig build http.zig
 // Run with:    ./zig-out/bin/example_1_httpz
@@ -163,7 +163,7 @@ fn patchElements(_: *httpz.Request, res: *httpz.Response) !void {
     res.header("X-SSE-More-Headers", "Patch Elements Example");
     res.header("X-SSE-Even-More-Headers", "All the Headers");
 
-    res.body = try datastar.patchElementsFmt(
+    res.body = try datastar.patchElementsFmtAlloc(
         res.arena,
         \\<p id="mf-patch">This is update number {d}</p>
     ,
@@ -192,13 +192,13 @@ fn patchElementsOpts(req: *httpz.Request, res: *httpz.Response) !void {
 
     beginSse(res);
     res.body = switch (patch_mode) {
-        .replace => try datastar.patchElements(
+        .replace => try datastar.patchElementsAlloc(
             res.arena,
             \\<p id="mf-patch-opts" class="border-4 border-error">Complete Replacement of the OUTER HTML</p>
         ,
             opts,
         ),
-        else => try datastar.patchElementsFmt(
+        else => try datastar.patchElementsFmtAlloc(
             res.arena,
             \\<p>This is update number {d}</p>
         ,
@@ -210,7 +210,7 @@ fn patchElementsOpts(req: *httpz.Request, res: *httpz.Response) !void {
 
 fn patchElementsOptsReset(_: *httpz.Request, res: *httpz.Response) !void {
     beginSse(res);
-    res.body = try datastar.patchElements(res.arena, @embedFile("01_index_opts.html"), .{});
+    res.body = try datastar.patchElementsAlloc(res.arena, @embedFile("01_index_opts.html"), .{});
 }
 
 // Plain JSON response — Datastar can pick up signals from a regular JSON body.
@@ -224,7 +224,7 @@ fn patchSignals(_: *httpz.Request, res: *httpz.Response) !void {
     beginSse(res);
     const foo = prng.random().intRangeAtMost(u8, 0, 255);
     const bar = prng.random().intRangeAtMost(u8, 0, 255);
-    res.body = try datastar.patchSignals(res.arena, .{ .foo = foo, .bar = bar }, .{});
+    res.body = try datastar.patchSignalsAlloc(res.arena, .{ .foo = foo, .bar = bar }, .{});
 }
 
 // Two SSE blocks in one response — just concatenate.
@@ -233,12 +233,12 @@ fn patchSignalsOnlyIfMissing(_: *httpz.Request, res: *httpz.Response) !void {
     const foo = prng.random().intRangeAtMost(u8, 1, 100);
     const bar = prng.random().intRangeAtMost(u8, 1, 100);
 
-    const signals_block = try datastar.patchSignals(
+    const signals_block = try datastar.patchSignalsAlloc(
         res.arena,
         .{ .newfoo = foo, .newbar = bar },
         .{ .only_if_missing = true },
     );
-    const script_block = try datastar.executeScript(
+    const script_block = try datastar.executeScriptAlloc(
         res.arena,
         "console.log('Patched newfoo and newbar, but only if missing');",
         .{},
@@ -270,7 +270,7 @@ fn patchSignalsRemove(req: *httpz.Request, res: *httpz.Response) !void {
     );
 
     beginSse(res);
-    res.body = try datastar.patchSignals(res.arena, parsed, .{});
+    res.body = try datastar.patchSignalsAlloc(res.arena, parsed, .{});
 }
 
 const snippets = [_][]const u8{
@@ -297,12 +297,12 @@ fn executeScript(req: *httpz.Request, res: *httpz.Response) !void {
 
     beginSse(res);
     res.body = switch (sample) {
-        1 => try datastar.executeScript(
+        1 => try datastar.executeScriptAlloc(
             res.arena,
             "console.log('Running from executeScript() directly');",
             .{},
         ),
-        2 => try datastar.executeScript(
+        2 => try datastar.executeScriptAlloc(
             res.arena,
             \\console.log('Multiline Script, using executeScript with a built-up payload');
             \\parent = document.querySelector('#execute-script-page');
@@ -310,13 +310,13 @@ fn executeScript(req: *httpz.Request, res: *httpz.Response) !void {
         ,
             .{ .attributes = attribs },
         ),
-        3 => try datastar.executeScriptFmt(
+        3 => try datastar.executeScriptFmtAlloc(
             res.arena,
             "console.log('Using formatted print {d}');",
             .{sample},
             .{},
         ),
-        else => try datastar.executeScriptFmt(
+        else => try datastar.executeScriptFmtAlloc(
             res.arena,
             "console.log('Unknown SampleID {d}');",
             .{sample},
@@ -386,7 +386,7 @@ fn emitSvgFrame(
     args: anytype,
 ) !void {
     fba.reset();
-    const block = try datastar.patchElementsFmt(fba.allocator(), fmt, args, .{ .namespace = .svg });
+    const block = try datastar.patchElementsFmtAlloc(fba.allocator(), fmt, args, .{ .namespace = .svg });
     try streamWriteAll(stream, shared_io, block);
 }
 
@@ -410,14 +410,14 @@ fn mathMorph(req: *httpz.Request, res: *httpz.Response) !void {
     if (opt.mathmlMorph == 1) {
         // Quick-fire single update — no streaming needed.
         beginSse(res);
-        const a = try datastar.patchElementsFmt(
+        const a = try datastar.patchElementsFmtAlloc(
             res.arena,
             \\<mn id="math-factor" class="text-red-500 font-bold">{}</mn>
         ,
             .{prng.random().intRangeAtMost(u16, 2, 22)},
             .{ .namespace = .mathml, .view_transition = true },
         );
-        const b = try datastar.patchSignals(res.arena, .{ .mathmlMorph = 1 }, .{});
+        const b = try datastar.patchSignalsAlloc(res.arena, .{ .mathmlMorph = 1 }, .{});
         res.body = try std.mem.concat(res.arena, u8, &.{ a, b });
         return;
     }
@@ -438,7 +438,7 @@ fn mathMorph(req: *httpz.Request, res: *httpz.Response) !void {
     for (0..opt.mathmlMorph) |_| {
         fba.reset();
         const r = prng.random().intRangeAtMost(u8, 1, mathMLs.len);
-        const block = try datastar.patchElements(
+        const block = try datastar.patchElementsAlloc(
             fba.allocator(),
             mathMLs[r - 1],
             .{ .namespace = .mathml },
@@ -448,7 +448,7 @@ fn mathMorph(req: *httpz.Request, res: *httpz.Response) !void {
     }
 
     fba.reset();
-    const reset_block = try datastar.patchSignals(fba.allocator(), .{ .mathmlMorph = 1 }, .{});
+    const reset_block = try datastar.patchSignalsAlloc(fba.allocator(), .{ .mathmlMorph = 1 }, .{});
     try streamWriteAll(stream, shared_io, reset_block);
 }
 
@@ -483,7 +483,7 @@ fn code(req: *httpz.Request, res: *httpz.Response) !void {
     const selector = try std.fmt.allocPrint(res.arena, "#code-{}", .{snip});
 
     beginSse(res);
-    res.body = try datastar.patchElements(
+    res.body = try datastar.patchElementsAlloc(
         res.arena,
         html.written(),
         .{ .selector = selector, .mode = .append },
@@ -521,7 +521,7 @@ fn hotreload(req: *httpz.Request, res: *httpz.Response) !void {
 
     if (id != hotreload_id) {
         std.log.warn("Client is stale {} != {} - reload them", .{ id, hotreload_id });
-        const block = try datastar.executeScript(fba.allocator(), "window.location.reload()", .{});
+        const block = try datastar.executeScriptAlloc(fba.allocator(), "window.location.reload()", .{});
         try streamWriteAll(stream, shared_io, block);
         return;
     }
@@ -541,7 +541,7 @@ fn hotreload(req: *httpz.Request, res: *httpz.Response) !void {
         ,
             .{seconds},
         );
-        const block = try datastar.patchElements(fba.allocator(), ping, .{});
+        const block = try datastar.patchElementsAlloc(fba.allocator(), ping, .{});
         try streamWriteAll(stream, shared_io, block);
     }
 }

--- a/src/datastar.zig
+++ b/src/datastar.zig
@@ -93,60 +93,114 @@ pub const DEFAULT_BUFFER_SIZE = 8 * 1024;
 
 // Framework-agnostic transformer functions.
 //
-// Each one takes an arena allocator, a payload, and the relevant options struct,
-// and returns a freshly-allocated string containing the SSE event-stream payload
-// ready to be written verbatim into whatever response body your HTTP framework exposes.
-//
-// The arena owns the returned slice; free it by resetting/freeing the arena.
+// The unsuffixed functions write a framed SSE event to a caller `*Io.Writer`.
+// The `*Alloc` variants return an arena-owned slice for frameworks that need a
+// complete response body.
 
-pub fn patchElements(arena: Allocator, elements: []const u8, opt: PatchElementsOptions) ![]const u8 {
-    var buf: Io.Writer.Allocating = .init(arena);
+const elements_data_prefix = "data: elements ";
+const signals_data_prefix = "data: signals ";
+
+/// Upper bound on the framed SSE size for a patch-elements payload. Used to
+/// pre-size the allocating writer so `patchElementsAlloc` does not
+/// abandon a doubling ladder of intermediate blocks.
+fn patchElementsSseCapacity(elements: []const u8, opt: PatchElementsOptions) usize {
+    // Fixed framing with headroom for optional fields (id/retry/mode/namespace
+    // /view-transition). A no-options single-line patch is only 48 bytes over
+    // the fragment; 256 covers the full options set with room to spare.
+    var cap: usize = 256;
+    if (opt.event_id) |id| cap += id.len;
+    if (opt.selector) |s| cap += s.len;
+    if (opt.view_transition_selector) |s| cap += s.len;
+    // One prefix per line; +1 covers the common no-trailing-newline case
+    // (overestimates by one prefix when the payload ends in '\n' — fine).
+    const lines = std.mem.count(u8, elements, "\n") + 1;
+    cap += elements.len + lines * elements_data_prefix.len;
+    return cap;
+}
+
+fn executeScriptSseCapacity(script: []const u8, opt: ExecuteScriptOptions) usize {
+    var cap: usize = 256; // fixed headers + <script…> / </script> + trailing \n\n
+    if (opt.event_id) |id| cap += id.len;
+    if (opt.attributes) |attribs| {
+        for (attribs.keys(), attribs.values()) |key, value| {
+            cap += key.len + value.len + 4; // space + key + =""
+        }
+    }
+    const lines = std.mem.count(u8, script, "\n") + 1;
+    cap += script.len + lines * elements_data_prefix.len;
+    return cap;
+}
+
+/// Stream a patch-elements SSE event into `writer`.
+pub fn patchElements(writer: *Io.Writer, elements: []const u8, opt: PatchElementsOptions) !void {
     var msg: Message = .{};
-    msg.init(.patchElements, opt, &buf.writer);
+    msg.init(.patchElements, opt, writer);
     try msg.header();
     try msg.interface.writeAll(elements);
     try msg.end();
+}
+
+/// Allocate and return a complete patch-elements SSE event.
+pub fn patchElementsAlloc(arena: Allocator, elements: []const u8, opt: PatchElementsOptions) ![]const u8 {
+    var buf: Io.Writer.Allocating = try .initCapacity(arena, patchElementsSseCapacity(elements, opt));
+    try patchElements(&buf.writer, elements, opt);
     return buf.written();
 }
 
-pub fn patchElementsFmt(arena: Allocator, comptime elements: []const u8, args: anytype, opt: PatchElementsOptions) ![]const u8 {
-    var buf: Io.Writer.Allocating = .init(arena);
+pub fn patchElementsFmt(writer: *Io.Writer, comptime elements: []const u8, args: anytype, opt: PatchElementsOptions) !void {
     var msg: Message = .{};
-    msg.init(.patchElements, opt, &buf.writer);
+    msg.init(.patchElements, opt, writer);
     try msg.header();
     try msg.interface.print(elements, args);
     try msg.end();
+}
+
+pub fn patchElementsFmtAlloc(arena: Allocator, comptime elements: []const u8, args: anytype, opt: PatchElementsOptions) ![]const u8 {
+    var buf: Io.Writer.Allocating = .init(arena);
+    try patchElementsFmt(&buf.writer, elements, args, opt);
     return buf.written();
 }
 
-pub fn patchSignals(arena: Allocator, signals: anytype, opt: PatchSignalsOptions) ![]const u8 {
-    var buf: Io.Writer.Allocating = .init(arena);
+pub fn patchSignals(writer: *Io.Writer, signals: anytype, opt: PatchSignalsOptions) !void {
     var msg: Message = .{};
-    msg.init(.patchSignals, opt, &buf.writer);
+    msg.init(.patchSignals, opt, writer);
     try msg.header();
     const json_formatter = std.json.fmt(signals, .{});
     try json_formatter.format(&msg.interface);
     try msg.end();
+}
+
+pub fn patchSignalsAlloc(arena: Allocator, signals: anytype, opt: PatchSignalsOptions) ![]const u8 {
+    var buf: Io.Writer.Allocating = .init(arena);
+    try patchSignals(&buf.writer, signals, opt);
     return buf.written();
 }
 
-pub fn executeScript(arena: Allocator, script: []const u8, opt: ExecuteScriptOptions) ![]const u8 {
-    var buf: Io.Writer.Allocating = .init(arena);
+pub fn executeScript(writer: *Io.Writer, script: []const u8, opt: ExecuteScriptOptions) !void {
     var msg: Message = .{};
-    msg.init(.executeScript, opt, &buf.writer);
+    msg.init(.executeScript, opt, writer);
     try msg.header();
     try msg.interface.writeAll(script);
     try msg.end();
+}
+
+pub fn executeScriptAlloc(arena: Allocator, script: []const u8, opt: ExecuteScriptOptions) ![]const u8 {
+    var buf: Io.Writer.Allocating = try .initCapacity(arena, executeScriptSseCapacity(script, opt));
+    try executeScript(&buf.writer, script, opt);
     return buf.written();
 }
 
-pub fn executeScriptFmt(arena: Allocator, comptime script: []const u8, args: anytype, opt: ExecuteScriptOptions) ![]const u8 {
-    var buf: Io.Writer.Allocating = .init(arena);
+pub fn executeScriptFmt(writer: *Io.Writer, comptime script: []const u8, args: anytype, opt: ExecuteScriptOptions) !void {
     var msg: Message = .{};
-    msg.init(.executeScript, opt, &buf.writer);
+    msg.init(.executeScript, opt, writer);
     try msg.header();
     try msg.interface.print(script, args);
     try msg.end();
+}
+
+pub fn executeScriptFmtAlloc(arena: Allocator, comptime script: []const u8, args: anytype, opt: ExecuteScriptOptions) ![]const u8 {
+    var buf: Io.Writer.Allocating = .init(arena);
+    try executeScriptFmt(&buf.writer, script, args, opt);
     return buf.written();
 }
 
@@ -517,8 +571,8 @@ pub const Message = struct {
     // implementation of writeBytes using SIMD scan of the input to find newlines
     fn writeBytesScan(self: *Message, stream_writer: *Io.Writer, bytes: []const u8) !usize {
         const prefix = switch (self.command) {
-            .patchElements, .executeScript => "data: elements ",
-            .patchSignals => "data: signals ",
+            .patchElements, .executeScript => elements_data_prefix,
+            .patchSignals => signals_data_prefix,
         };
 
         var rest = bytes;
@@ -694,7 +748,7 @@ test "patchElements transformer emits SSE event stream" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const out = try patchElements(arena, "<div id='hello'>Hi</div>", .{});
+    const out = try patchElementsAlloc(arena, "<div id='hello'>Hi</div>", .{});
     try std.testing.expectEqualStrings(
         "event: datastar-patch-elements\ndata: elements <div id='hello'>Hi</div>\n\n",
         out,
@@ -706,7 +760,7 @@ test "patchElements transformer honours options" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const out = try patchElements(arena, "<p>x</p>", .{
+    const out = try patchElementsAlloc(arena, "<p>x</p>", .{
         .mode = .inner,
         .selector = "#main",
         .view_transition = true,
@@ -724,7 +778,7 @@ test "patchElements transformer prefixes each line of multiline input" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const out = try patchElements(arena, "<div>\n  <p>hi</p>\n</div>", .{});
+    const out = try patchElementsAlloc(arena, "<div>\n  <p>hi</p>\n</div>", .{});
     try std.testing.expectEqualStrings(
         "event: datastar-patch-elements\ndata: elements <div>\ndata: elements   <p>hi</p>\ndata: elements </div>\n\n",
         out,
@@ -736,7 +790,7 @@ test "patchElementsFmt transformer formats payload" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const out = try patchElementsFmt(arena, "<p id='c'>count {d}</p>", .{42}, .{});
+    const out = try patchElementsFmtAlloc(arena, "<p id='c'>count {d}</p>", .{42}, .{});
     try std.testing.expectEqualStrings(
         "event: datastar-patch-elements\ndata: elements <p id='c'>count 42</p>\n\n",
         out,
@@ -748,7 +802,7 @@ test "patchSignals transformer emits JSON payload" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const out = try patchSignals(arena, .{ .foo = 42, .bar = "baz" }, .{});
+    const out = try patchSignalsAlloc(arena, .{ .foo = 42, .bar = "baz" }, .{});
     try std.testing.expectEqualStrings(
         "event: datastar-patch-signals\ndata: signals {\"foo\":42,\"bar\":\"baz\"}\n\n",
         out,
@@ -760,7 +814,7 @@ test "patchSignals transformer honours only_if_missing" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const out = try patchSignals(arena, .{ .x = 1 }, .{ .only_if_missing = true });
+    const out = try patchSignalsAlloc(arena, .{ .x = 1 }, .{ .only_if_missing = true });
     try std.testing.expectEqualStrings(
         "event: datastar-patch-signals\ndata: onlyIfMissing true\ndata: signals {\"x\":1}\n\n",
         out,
@@ -772,7 +826,7 @@ test "executeScript transformer wraps payload in a script tag" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const out = try executeScript(arena, "console.log('hi')", .{});
+    const out = try executeScriptAlloc(arena, "console.log('hi')", .{});
     try std.testing.expectEqualStrings(
         "event: datastar-patch-elements\ndata: mode append\ndata: selector body\ndata: elements <script data-effect=\"el.remove()\">console.log('hi')</script>\n\n",
         out,
@@ -784,11 +838,72 @@ test "executeScriptFmt transformer formats payload" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const out = try executeScriptFmt(arena, "alert('hi {s}')", .{"world"}, .{ .auto_remove = false });
+    const out = try executeScriptFmtAlloc(arena, "alert('hi {s}')", .{"world"}, .{ .auto_remove = false });
     try std.testing.expectEqualStrings(
         "event: datastar-patch-elements\ndata: mode append\ndata: selector body\ndata: elements <script>alert('hi world')</script>\n\n",
         out,
     );
+}
+
+test "patchElements matches patchElementsAlloc" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const html = "<div>\n  <p>hi</p>\n</div>";
+    const opts: PatchElementsOptions = .{ .selector = "#main", .mode = .inner };
+
+    const from_slice = try patchElementsAlloc(arena, html, opts);
+
+    var buf: Io.Writer.Allocating = .init(arena);
+    try patchElements(&buf.writer, html, opts);
+
+    try std.testing.expectEqualStrings(from_slice, buf.written());
+}
+
+test "patchElementsAlloc pre-sizes so an empty arena holds ~1x the framed output" {
+    // Fragment lives outside the arena so we measure only the framing alloc.
+    const fragment = try std.testing.allocator.alloc(u8, 1024 * 1024);
+    defer std.testing.allocator.free(fragment);
+    @memset(fragment, 'x');
+    fragment[0] = '<';
+    fragment[1000] = '\n';
+    fragment[100_000] = '\n';
+    fragment[fragment.len - 1] = '>';
+
+    var arena_inst = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_inst.deinit();
+
+    const before = arena_inst.queryCapacity();
+    const out = try patchElementsAlloc(arena_inst.allocator(), fragment, .{});
+    const after = arena_inst.queryCapacity();
+
+    try std.testing.expect(out.len >= fragment.len);
+    try std.testing.expect(out.len <= fragment.len + 256);
+    const grown = after - before;
+    try std.testing.expect(grown < out.len * 2);
+}
+
+test "patchElements frames without retaining a copy in the caller's arena" {
+    var arena_inst = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_inst.deinit();
+    const arena = arena_inst.allocator();
+
+    // Fragment already resident in the arena; framing to a writer must not
+    // allocate more arena capacity.
+    const fragment = try arena.alloc(u8, 256 * 1024);
+    @memset(fragment, 'y');
+    fragment[0] = '<';
+    fragment[fragment.len - 1] = '>';
+
+    const before = arena_inst.queryCapacity();
+
+    var sink: [256 * 1024 + 4096]u8 = undefined;
+    var writer = Io.Writer.fixed(sink[0..]);
+    try patchElements(&writer, fragment, .{});
+
+    try std.testing.expectEqual(before, arena_inst.queryCapacity());
+    try std.testing.expect(writer.end > fragment.len);
 }
 
 test "PatchElementsOptions with custom values" {


### PR DESCRIPTION
## Summary
- Make `patchElements`, `patchSignals`, and `executeScript` write framed SSE to a caller `*Io.Writer` and return `!void`. This is the default path.
- Move the old arena-returning forms to explicit `*Alloc` names (`patchElementsAlloc`, and the same for signals and scripts).
- Pre-size the allocating writer in `*Alloc` so a growth sequence from zero does not keep many discarded blocks in the arena.
- Add `zig build peak-rss`: each (mode × placement × size) runs in a child process and reports `req_bytes`, `arena_cap`, and RSS delta.
- Update the README and the http.zig / dusty adapters for the new names.

**Measurement (fragment = 4,732,869 bytes already in the arena):**

| path | req_bytes | arena_cap growth | req/frag |
| --- | ---: | ---: | ---: |
| Allocating from zero | 57.8 MB | 31.7 MB | 12.2× |
| `*Alloc` (pre-size) | 24.8 MB | 17.7 MB | 5.25× |
| stream to writer | **0** | **0** | **0.00** |

This agrees with the Datastar SDK ADR (`ServerSentEventGenerator.send`: write to the response and flush).

**Out of scope:** change the bundled `SSE` methods. Those already write into their output buffer. This pull request changes only the free-standing transformers.

**Breaking change:** SDK-only callers must pass a writer to the unsuffixed functions, or call `*Alloc` when they need an arena-owned slice.

Closes #16

## Test plan
- [ ] `zig build test` — 58 tests pass (23 datastar + 35 server)
- [ ] `zig build http.zig` and `zig build dusty` compile
- [ ] `zig build peak-rss` prints the table; stream shows `req_bytes = 0` for the in-arena 4.7 MB case
- [ ] `patchElements` / `patchElementsAlloc` give the same framed bytes
- [ ] Bundled `sse.patchElements` behavior does not change

### New unit tests (branch coverage)
- `patchElements matches patchElementsAlloc`
- `patchElementsAlloc pre-sizes so an empty arena holds ~1x the framed output`
- `patchElements frames without retaining a copy in the caller's arena`

## AI disclosure
An AI coding agent (Cursor) helped develop this change. I set the goals and limits, I reviewed each diff, I ran and directed the peak-rss measurements that support the defaults, and I am responsible for the correctness of the patch. Do not treat AI-generated content as unchecked.

Made with [Cursor](https://cursor.com)
